### PR TITLE
Updated ISessionFactory to register as transient

### DIFF
--- a/Mongo/docker-compose.yaml
+++ b/Mongo/docker-compose.yaml
@@ -1,5 +1,9 @@
 version: "3.8"
 
+networks:
+  tx-command-mongo:
+    driver: bridge
+
 services:
   mongo1:
     container_name: mongo1
@@ -8,27 +12,27 @@ services:
       dockerfile: primary.Dockerfile
     ports:
       - 30001:30001
-    volumes:
-      - ./data/mongo-1:/data/db
     healthcheck:
       test: test $$(echo "rs.initiate({_id:'my-replica-set',members:[{_id:0,host:\"mongo1:30001\"},{_id:1,host:\"mongo2:30002\"},{_id:2,host:\"mongo3:30003\"}]}).ok || rs.status().ok" | mongo --port 30001 --quiet) -eq 1
       interval: 10s
       start_period: 30s
+    networks:
+      - tx-command-mongo
 
   mongo2:
     image: mongo:4.2
     container_name: mongo2
     command: ["--replSet", "my-replica-set", "--bind_ip_all", "--port", "30002"]
-    volumes:
-      - ./data/mongo-2:/data/db
     ports:
       - 30002:30002
+    networks:
+      - tx-command-mongo
 
   mongo3:
     image: mongo:4.2
     container_name: mongo3
     command: ["--replSet", "my-replica-set", "--bind_ip_all", "--port", "30003"]
-    volumes:
-      - ./data/mongo-3:/data/db
     ports:
       - 30003:30003
+    networks:
+      - tx-command-mongo

--- a/Mongo/entrypoint.sh
+++ b/Mongo/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 init(){
-    sleep 25
+    sleep 30
 
     echo -e "\n\n\nCreating collections...\n\n\n"
     mongo localhost:30001 <<EOF

--- a/Sql/TxCommand.Sql/BuilderExtensions.cs
+++ b/Sql/TxCommand.Sql/BuilderExtensions.cs
@@ -22,7 +22,7 @@ namespace TxCommand
             builder.Services.AddSingleton(sqlOptions);
             builder.Services.TryAddTransient<ITransactionProvider<IDbConnection, IDbTransaction>, TransactionProvider>();
             builder.Services.TryAddTransient<ISession, Session>();
-            builder.Services.TryAddSingleton<ISessionFactory, SessionFactory>();
+            builder.Services.TryAddTransient<ISessionFactory, SessionFactory>();
 
             return builder;
         }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -34,6 +34,7 @@ cd Mongo
 
 echo "Starting Docker environment..."
 docker-compose up -d & sleep 35
+docker-compose logs
 
 echo "Running tests..."
 run_test TxCommand.Mongo.Net5.Tests/TxCommand.Mongo.Net5.Tests.csproj TxCommand.Mongo.Net5.Tests

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -33,7 +33,7 @@ echo "Running Mongo tests..."
 cd Mongo
 
 echo "Starting Docker environment..."
-docker-compose up -d & sleep 35
+docker-compose up -d && sleep 35
 docker-compose logs
 
 echo "Running tests..."

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -33,7 +33,7 @@ echo "Running Mongo tests..."
 cd Mongo
 
 echo "Starting Docker environment..."
-docker-compose up -d & sleep 30
+docker-compose up -d & sleep 35
 
 echo "Running tests..."
 run_test TxCommand.Mongo.Net5.Tests/TxCommand.Mongo.Net5.Tests.csproj TxCommand.Mongo.Net5.Tests


### PR DESCRIPTION
When using `SqlServer`, the session factory would end up using a single `SqlConnection` instance which doesn't support parallel transactions. Alongside that, it wouldn't be able to resolve a scoped instance of `SqlConnection` as it's a singleton. The solution is to register it as transient and allow the consuming application to manage how `ISessionFactory` is handled through dependent service's lifetimes.