### PR TITLE
Allow class overrides

### DIFF
--- a/src/TxCommand.Mongo/TransactionProvider.cs
+++ b/src/TxCommand.Mongo/TransactionProvider.cs
@@ -21,7 +21,7 @@ namespace TxCommand
             _options = options ?? throw new ArgumentNullException(nameof(options));
         }
 
-        public async Task EnsureTransactionAsync(CancellationToken cancellationToken)
+        public virtual async Task EnsureTransactionAsync(CancellationToken cancellationToken)
         {
             if (_disposed)
             {
@@ -39,7 +39,7 @@ namespace TxCommand
             }
         }
 
-        public Task CommitAsync(CancellationToken cancellationToken)
+        public virtual Task CommitAsync(CancellationToken cancellationToken)
         {
             if (_disposed)
             {
@@ -54,7 +54,7 @@ namespace TxCommand
             return _session.CommitTransactionAsync(cancellationToken);
         }
 
-        public void Commit()
+        public virtual void Commit()
         {
             if (_disposed)
             {
@@ -69,7 +69,7 @@ namespace TxCommand
             _session.CommitTransaction();
         }
 
-        public Task RollbackAsync(CancellationToken cancellationToken)
+        public virtual Task RollbackAsync(CancellationToken cancellationToken)
         {
             if (_disposed)
             {
@@ -84,7 +84,7 @@ namespace TxCommand
             return _session.AbortTransactionAsync(cancellationToken);
         }
 
-        public (IMongoClient database, IClientSessionHandle transaction) GetExecutionArguments()
+        public virtual (IMongoClient database, IClientSessionHandle transaction) GetExecutionArguments()
         {
             if (_disposed)
             {
@@ -94,7 +94,7 @@ namespace TxCommand
             return (_client, _session);
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             if (_disposed)
             {

--- a/src/TxCommand.Mongo/TxCommand.Mongo.csproj
+++ b/src/TxCommand.Mongo/TxCommand.Mongo.csproj
@@ -11,6 +11,7 @@
     <RepositoryUrl>https://github.com/reecerussell/tx-command</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>cqrs, commanding, tx, transactional, sql, mongo, nosql</PackageTags>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TxCommand.Sql/TransactionProvider.cs
+++ b/src/TxCommand.Sql/TransactionProvider.cs
@@ -21,7 +21,7 @@ namespace TxCommand
             _options = options ?? throw new ArgumentNullException(nameof(options));
         }
 
-        public Task EnsureTransactionAsync(CancellationToken cancellationToken)
+        public virtual Task EnsureTransactionAsync(CancellationToken cancellationToken)
         {
             if (_disposed)
             {
@@ -41,7 +41,7 @@ namespace TxCommand
             return Task.CompletedTask;
         }
 
-        public Task CommitAsync(CancellationToken cancellationToken)
+        public virtual Task CommitAsync(CancellationToken cancellationToken)
         {
             if (_disposed)
             {
@@ -53,7 +53,7 @@ namespace TxCommand
             return Task.CompletedTask;
         }
 
-        public void Commit()
+        public virtual void Commit()
         {
             if (_disposed)
             {
@@ -63,7 +63,7 @@ namespace TxCommand
             _transaction.Commit();
         }
 
-        public Task RollbackAsync(CancellationToken cancellationToken)
+        public virtual Task RollbackAsync(CancellationToken cancellationToken)
         {
             if (_disposed)
             {
@@ -75,7 +75,7 @@ namespace TxCommand
             return Task.CompletedTask;
         }
 
-        public (IDbConnection database, IDbTransaction transaction) GetExecutionArguments()
+        public virtual (IDbConnection database, IDbTransaction transaction) GetExecutionArguments()
         {
             if (_disposed)
             {
@@ -85,7 +85,7 @@ namespace TxCommand
             return (_connection, _transaction);
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             _transaction?.Dispose();
             _disposed = true;

--- a/src/TxCommand.Sql/TxCommand.Sql.csproj
+++ b/src/TxCommand.Sql/TxCommand.Sql.csproj
@@ -10,7 +10,7 @@
     <PackageTags>cqrs, msql, sql, mssql, commanding, query</PackageTags>
     <PackageProjectUrl>https://github.com/reecerussell/tx-command</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TxCommand/Session.cs
+++ b/src/TxCommand/Session.cs
@@ -26,7 +26,7 @@ namespace TxCommand
             _provider = provider;
         }
 
-        public async Task ExecuteAsync(ITxCommand<TDatabase, TTransaction> command)
+        public virtual async Task ExecuteAsync(ITxCommand<TDatabase, TTransaction> command)
         {
             if (_disposed)
             {
@@ -59,7 +59,7 @@ namespace TxCommand
             }
         }
 
-        public async Task<TResult> ExecuteAsync<TResult>(ITxCommand<TDatabase, TTransaction, TResult> command)
+        public virtual async Task<TResult> ExecuteAsync<TResult>(ITxCommand<TDatabase, TTransaction, TResult> command)
         {
             if (_disposed)
             {
@@ -94,7 +94,7 @@ namespace TxCommand
             }
         }
 
-        public async Task CommitAsync()
+        public virtual async Task CommitAsync()
         {
             if (_disposed)
             {
@@ -112,7 +112,7 @@ namespace TxCommand
             OnCommitted?.Invoke();
         }
 
-        public void Commit()
+        public virtual void Commit()
         {
             if (_disposed)
             {
@@ -130,7 +130,7 @@ namespace TxCommand
             OnCommitted?.Invoke();
         }
 
-        public async Task RollbackAsync()
+        public virtual async Task RollbackAsync()
         {
             if (_disposed)
             {
@@ -148,7 +148,7 @@ namespace TxCommand
             OnRolledBack?.Invoke();
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             if (_disposed)
             {
@@ -168,7 +168,7 @@ namespace TxCommand
 
 #if NET5_0
 
-        public async ValueTask DisposeAsync()
+        public virtual async ValueTask DisposeAsync()
         {
             if (_disposed)
             {

--- a/src/TxCommand/SessionFactory.cs
+++ b/src/TxCommand/SessionFactory.cs
@@ -14,6 +14,6 @@ namespace TxCommand
             Services = services;
         }
 
-        public TSession Create() => Services.GetRequiredService<TSession>();
+        public virtual TSession Create() => Services.GetRequiredService<TSession>();
     }
 }

--- a/src/TxCommand/TxCommand.csproj
+++ b/src/TxCommand/TxCommand.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <Authors>Reece Russell</Authors>
     <RepositoryUrl>https://github.com/reecerussell/tx-command</RepositoryUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
Currently if a consumer of the packages wanted to create an abstraction of, say, the `Session` class in the Sql package, they'd have to reimplement the current code. This change allows abstractions to be created and overridden by adding the `virtual` modifier to each method. 